### PR TITLE
Adjusted  item containers would stretch to fit all text content when …

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -138,11 +138,12 @@ a:link {
 
 .display-screen {
   width: 355px;
-  height: 675px;
+  min-height: 450px;
   background-color: #fff5d7;
   border-radius: 15px;
   display: flex;
   align-items: center;
+  margin-bottom: 3em;
 }
 
 .text-400 {
@@ -193,7 +194,7 @@ a:link {
 
 .display-screen-item {
   width: 355px;
-  height: 400px;
+  height: 100%;
   background-color: #fff5d7;
   border-radius: 15px;
   display: flex;
@@ -291,14 +292,14 @@ a:link {
 
   .display-screen {
     width: 500px;
-    height: 600px;
+    min-height: 600px;
     justify-content: center;
     box-shadow: 0 0 2px black;
   }
 
   .display-screen-item {
     width: 500px;
-    height: 600px;
+    height: 100%;
   }
 
   .item-background {


### PR DESCRIPTION
…rendered instead of overflowing